### PR TITLE
LOD Support

### DIFF
--- a/nif_export.py
+++ b/nif_export.py
@@ -543,6 +543,10 @@ class Empty(SceneNode):
         # set flags
         self.output.flags |= self.source.mw.object_flags
 
+        # LOD nodes only need to update whichever level is actively visible
+        if isinstance(self.output, nif.NiLODNode):
+            self.output.update_only_active = True
+
         # set hidden
         if self.output.is_shadow:
             self.output.app_culled = True

--- a/nif_export.py
+++ b/nif_export.py
@@ -525,7 +525,7 @@ class Empty(SceneNode):
                 self.output = nif.RootCollisionNode(app_culled=True)
             elif self.name == "PickProxy":
                 self.output = nif.NiCollisionSwitch(propagate=True)
-            elif self.source.mw.is_lod_node:
+            elif self.source.mw.block_type == "NiLODNode":
                 self.output = nif.NiLODNode(lod_center=np.array(self.source.mw.lod_center, dtype="<f"))
             elif self.exporter.create_switch_nodes and self.name.startswith("SWITCH_"):
                 self.output = nif.NiSwitchNode()

--- a/nif_export.py
+++ b/nif_export.py
@@ -85,6 +85,11 @@ class Exporter:
                 cls(node).create()
                 node.animation.create()
 
+        # finalize lod levels
+        for node in self.nodes:
+            if isinstance(node.output, nif.NiLODNode):
+                self.finalize_lod_node(node)
+
         data = nif.NiStream()
         data.root = self.get_root_output(roots)
         data.apply_scale(self.scale_correction)
@@ -201,6 +206,23 @@ class Exporter:
                 s.modifiers.remove(m)
             for k in temp_mute_keys:
                 k.mute = False
+
+    def finalize_lod_node(self, node):
+        """Build the LOD levels array from each child's 'Far Extent' property.
+
+        Children are used as LOD levels in order, from highest to lowest detail. Each
+        level's near extent is set to the previous level's far extent (0 for the first).
+        """
+        near = 0.0
+        lod_levels = []
+        for child in node.children:
+            if child.output is None:
+                continue
+            far = child.source.mw.lod_far_extent
+            lod_levels.append((near, far))
+            near = far
+
+        node.output.lod_levels = np.array(lod_levels, dtype="<f").reshape(-1, 2)
 
     def export_keyframe_data(self, data):
         nif_path = self.filepath
@@ -503,6 +525,8 @@ class Empty(SceneNode):
                 self.output = nif.RootCollisionNode(app_culled=True)
             elif self.name == "PickProxy":
                 self.output = nif.NiCollisionSwitch(propagate=True)
+            elif self.source.mw.is_lod_node:
+                self.output = nif.NiLODNode(lod_center=np.array(self.source.mw.lod_center, dtype="<f"))
             elif self.exporter.create_switch_nodes and self.name.startswith("SWITCH_"):
                 self.output = nif.NiSwitchNode()
             else:

--- a/nif_import.py
+++ b/nif_import.py
@@ -103,6 +103,11 @@ class Importer:
             if node.output is None:
                 cls(node).create()
 
+        # finalize lod levels
+        for node in self.nodes:
+            if isinstance(node.source, nif.NiLODNode):
+                self.finalize_lod_node(node)
+
         # unmute animations
         for node in map(self.get, self.armatures):
             node.animation.set_mute(False)
@@ -129,6 +134,20 @@ class Importer:
                     queue.extend(SceneNode(self, child, node) for child in node.source.children_of_type(nif.NiAVObject))
 
         return root_nodes
+
+    def finalize_lod_node(self, node):
+        """Restore LOD properties from a NiLODNode onto its Blender objects.
+
+        Children are used as LOD levels in order, from highest to lowest detail. Only
+        each level's far extent is preserved; the near extent is expected to equal the
+        previous level's far extent (0 for the first), and is recomputed on export.
+        """
+        node.output.mw.is_lod_node = True
+        node.output.mw.lod_center = tuple(node.source.lod_center)
+
+        for child, (near, far) in zip(node.children, node.source.lod_levels):
+            if child.output is not None:
+                child.output.mw.lod_far_extent = float(far)
 
     def resolve_armatures(self):
         """ TODO

--- a/nif_import.py
+++ b/nif_import.py
@@ -142,7 +142,7 @@ class Importer:
         each level's far extent is preserved; the near extent is expected to equal the
         previous level's far extent (0 for the first), and is recomputed on export.
         """
-        node.output.mw.is_lod_node = True
+        node.output.mw.block_type = "NiLODNode"
         node.output.mw.lod_center = tuple(node.source.lod_center)
 
         for child, (near, far) in zip(node.children, node.source.lod_levels):

--- a/panels/object_panel.py
+++ b/panels/object_panel.py
@@ -15,9 +15,9 @@ class ObjectPanel(bpy.types.Panel):
         layout.prop(ob.mw, "object_flags")
 
         layout.separator()
-        layout.prop(ob.mw, "is_lod_node")
-        if ob.mw.is_lod_node:
+        layout.prop(ob.mw, "block_type")
+        if ob.mw.block_type == "NiLODNode":
             layout.prop(ob.mw, "lod_center")
 
-        if (ob.parent is not None) and ob.parent.mw.is_lod_node:
+        if (ob.parent is not None) and (ob.parent.mw.block_type == "NiLODNode"):
             layout.prop(ob.mw, "lod_far_extent")

--- a/panels/object_panel.py
+++ b/panels/object_panel.py
@@ -10,4 +10,14 @@ class ObjectPanel(bpy.types.Panel):
 
     def draw(self, context):
         ob = context.active_object
-        self.layout.prop(ob.mw, "object_flags")
+        layout = self.layout
+
+        layout.prop(ob.mw, "object_flags")
+
+        layout.separator()
+        layout.prop(ob.mw, "is_lod_node")
+        if ob.mw.is_lod_node:
+            layout.prop(ob.mw, "lod_center")
+
+        if (ob.parent is not None) and ob.parent.mw.is_lod_node:
+            layout.prop(ob.mw, "lod_far_extent")

--- a/properties/object_properties.py
+++ b/properties/object_properties.py
@@ -4,14 +4,14 @@ import bpy
 class ObjectProperties(bpy.types.PropertyGroup):
     object_flags: bpy.props.IntProperty(name="Flags", min=0, max=65535, default=2)
 
-    is_lod_node: bpy.props.BoolProperty(
-        name="LOD Node",
-        description=(
-            "Export this object as a NiLODNode."
-            " Children are used as LOD levels, ordered from highest to lowest detail,"
-            " each visible within its own 'Far Extent' distance range"
-        ),
-        default=False,
+    block_type: bpy.props.EnumProperty(
+        name="Block Type",
+        description="The NIF block type this object will be exported as",
+        items=[
+            ("NiNode", "NiNode", "A regular node"),
+            ("NiLODNode", "NiLODNode", "A node whose children are used as LOD levels"),
+        ],
+        default="NiNode",
     )
 
     lod_center: bpy.props.FloatVectorProperty(

--- a/properties/object_properties.py
+++ b/properties/object_properties.py
@@ -4,6 +4,34 @@ import bpy
 class ObjectProperties(bpy.types.PropertyGroup):
     object_flags: bpy.props.IntProperty(name="Flags", min=0, max=65535, default=2)
 
+    is_lod_node: bpy.props.BoolProperty(
+        name="LOD Node",
+        description=(
+            "Export this object as a NiLODNode."
+            " Children are used as LOD levels, ordered from highest to lowest detail,"
+            " each visible within its own 'Far Extent' distance range"
+        ),
+        default=False,
+    )
+
+    lod_center: bpy.props.FloatVectorProperty(
+        name="LOD Center",
+        description="Center point used for LOD distance calculations, in local space",
+        size=3,
+        default=(0.0, 0.0, 0.0),
+        subtype="XYZ",
+    )
+
+    lod_far_extent: bpy.props.FloatProperty(
+        name="Far Extent",
+        description=(
+            "Maximum distance, in game units, at which this LOD level is visible."
+            " The near distance is set automatically to the previous level's far extent (0 for the first level)"
+        ),
+        default=0.0,
+        min=0.0,
+    )
+
     @staticmethod
     def register() -> None:
         bpy.types.Object.mw = bpy.props.PointerProperty(type=ObjectProperties)


### PR DESCRIPTION
Adds a new `Block Type` property for objects. By default, this is NiNode. If you set it to NiLODNode, you can configure children objects to use LOD extent properties.

Tested by importing a nif with a LOD container, looking at the properties in Blender, then exporting back to a new NIF. Then I compared the properties between the original and new file in NifSkope.

<img width="479" height="1236" alt="image" src="https://github.com/user-attachments/assets/8b34e9c3-ab95-4dbd-ad96-c4c58dab8b22" />
